### PR TITLE
add in command for linting using tslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "typescript-tooling:test": "tst test typescript-tooling",
     "typescript-tooling:test:watch": "tst test typescript-tooling --watch",
     "typescript-tooling:dev": "tst dev typescript-tooling",
-    "typescript-tooling:build": "tst build typescript-tooling"
+    "typescript-tooling:build": "tst build typescript-tooling",
+    "typescript-tooling:lint": "tst lint typescript-tooling"
   },
   "devDependencies": {
     "@types/jest": "^23.3.1",

--- a/packages/typescript-tooling/src/Lint.ts
+++ b/packages/typescript-tooling/src/Lint.ts
@@ -1,0 +1,14 @@
+import * as Log from "./Log";
+import * as Shell from "./Shell";
+
+export const help = `Lints ${Log.arg("<package-name>")} with ${Log.tool(
+  "TSLint"
+)}`;
+
+export const action = async (args: any, _: any, logger: Logger) => {
+  logger.info("");
+
+  const command = `npx tslint 'packages/${args.packageName}/src/**/*.ts?(x)'`;
+
+  process.exit(Shell.run(logger, command));
+};

--- a/packages/typescript-tooling/src/Scripts.ts
+++ b/packages/typescript-tooling/src/Scripts.ts
@@ -57,7 +57,8 @@ export const scripts = (packages: string[]) =>
       [`${packageName}:test`]: `tst test ${packageName}`,
       [`${packageName}:test:watch`]: `tst test ${packageName} --watch`,
       [`${packageName}:dev`]: `tst dev ${packageName}`,
-      [`${packageName}:build`]: `tst build ${packageName}`
+      [`${packageName}:build`]: `tst build ${packageName}`,
+      [`${packageName}:lint`]: `tst lint ${packageName}`
     }),
     {
       ["tst:init"]: "tst init --install false",

--- a/packages/typescript-tooling/src/index.ts
+++ b/packages/typescript-tooling/src/index.ts
@@ -11,6 +11,7 @@ import * as Scripts from "./Scripts";
 import * as Deps from "./Deps";
 
 import * as Test from "./Test";
+import * as Lint from "./Lint";
 import * as Dev from "./Dev";
 import * as Build from "./Build";
 
@@ -91,6 +92,11 @@ CLI.command("test", Test.help)
   .argument("<package-name>", Log.packages(packages), packages)
   .option("-w --watch", "Re-run tests on file changes", CLI.BOOLEAN, false)
   .action(Test.action);
+
+CLI.command("lint", Lint.help)
+  .help(Lint.help)
+  .argument("<package-name>", Log.packages(packages), packages)
+  .action(Lint.action);
 
 CLI.command("dev", Dev.help)
   .help(Dev.help)


### PR DESCRIPTION
I noticed that while tslint was being used there was no command to actually use it. Although it does give an editor the ability to underline stuff, I think there is usefulness in a command that runs it across a whole package. For example: when you convert an existing project with slightly different or no linting existing linting rules to using TST... unless you go through each file, you won't be able to easily find all the linting errors.

I'm not sure if this was by design or simply forgotten about but I figured I would make a PR anyways. Let me know what you're thinking!

Also, I wasn't immediately sure if there was a good way to develop but I used the command `npm run typescript-tooling:build; rm -rf ./node_modules/typescript-tooling/dist/; cp -R packages/typescript-tooling/dist/ ./node_modules/typescript-tooling/dist; npm run typescript-tooling:lint` to get a quick development pipeline going.

ALSO:
If you run this new command you'll notice that the typescript-tooling package itself does not pass its own linting.